### PR TITLE
refactor: Use unranked_items endpoint for list slash command

### DIFF
--- a/handlers/commands/getItems.js
+++ b/handlers/commands/getItems.js
@@ -63,7 +63,7 @@ module.exports = async (req, res) => {
     validateRequest.token(res, token, process.env.SLACK_VERIFICATION_TOKEN)
 
     const email = `${user_name}@${team_domain}.com`
-    const url = `${process.env.PANTRY_LIST_API_URL}/items?user=${email}`
+    const url = `${process.env.PANTRY_LIST_API_URL}/unranked_items?user=${email}`
     const response = await fetch(url, {
       headers: {
         authorization: `Basic ${process.env.SLACK_TOKEN}`,


### PR DESCRIPTION
# Task
https://trello.com/c/WwKpwKYZ/91-use-unrankeditems-endpoint-for-list-slash-command

# Goal
Restore `/list` slash command to a working state.

The `pantry-list-api` `items` endpoint used previously, was changed [here](https://github.com/SharpNotions/pantry-list-api/commit/81f5cec392d3396e2bdf959e580cc7ed8ab48c29#diff-bd9c9dcd314f2d7df52935b3a6a4d504L39) to `unranked_items`.

# Related
https://github.com/SharpNotions/pantry-list-slack-bot/pull/7

# People
@SharpNotions/ten-hour-project 
