### PR TITLE
fix: Use slack api to get user email

### DIFF
--- a/handlers/commands/addItem.js
+++ b/handlers/commands/addItem.js
@@ -8,6 +8,7 @@ const {
   requireText,
   logRequests
 } = require('./middleware')
+const { getUserEmail } = require('../../helpers')
 const { PANTRY_LIST_API_URL, SLACK_TOKEN } = process.env
 
 const parseRequestText = text => {
@@ -46,10 +47,10 @@ const enhanced = compose(
 )
 
 module.exports = enhanced(async (req, res) => {
-  const { text, team_domain, token, user_name } = await parse(req)
+  const { text, team_domain, token, user_name, user_id } = await parse(req)
 
   const data = parseRequestText(text)
-  const email = `${user_name}@${team_domain}.com`
+  const email = await getUser(user_id)
   const url = `${PANTRY_LIST_API_URL}/item?user=${email}`
 
   const response = await fetch(url, {

--- a/handlers/commands/getItems.js
+++ b/handlers/commands/getItems.js
@@ -2,7 +2,11 @@ const parse = require('urlencoded-body-parser')
 const fetch = require('node-fetch')
 const { send } = require('micro')
 const { getUserEmail } = require('../../helpers')
-const { SLACK_VERIFICATION_TOKEN, SLACK_TOKEN } = process.env
+const {
+  SLACK_VERIFICATION_TOKEN,
+  SLACK_TOKEN,
+  PANTRY_LIST_API_URL
+} = process.env
 const createAttachment = data => {
   let attachment = {
     color: '#7c4be0',
@@ -63,9 +67,7 @@ module.exports = async (req, res) => {
     validateRequest.token(res, token, SLACK_VERIFICATION_TOKEN)
 
     const email = await getUserEmail(user_id)
-    const url = `${
-      process.env.PANTRY_LIST_API_URL
-    }/unranked_items?user=${email}`
+    const url = `${PANTRY_LIST_API_URL}/unranked_items?user=${email}`
     const response = await fetch(url, {
       headers: {
         authorization: `Basic ${SLACK_TOKEN}`,

--- a/handlers/commands/getItems.js
+++ b/handlers/commands/getItems.js
@@ -1,8 +1,8 @@
 const parse = require('urlencoded-body-parser')
 const fetch = require('node-fetch')
-
 const { send } = require('micro')
-
+const { getUserEmail } = require('../../helpers')
+const { SLACK_VERIFICATION_TOKEN, SLACK_TOKEN } = process.env
 const createAttachment = data => {
   let attachment = {
     color: '#7c4be0',
@@ -58,15 +58,17 @@ const validateRequest = {
 
 module.exports = async (req, res) => {
   try {
-    const { team_domain, token, user_name } = await parse(req)
+    const { team_domain, token, user_name, user_id } = await parse(req)
 
-    validateRequest.token(res, token, process.env.SLACK_VERIFICATION_TOKEN)
+    validateRequest.token(res, token, SLACK_VERIFICATION_TOKEN)
 
-    const email = `${user_name}@${team_domain}.com`
-    const url = `${process.env.PANTRY_LIST_API_URL}/unranked_items?user=${email}`
+    const email = await getUserEmail(user_id)
+    const url = `${
+      process.env.PANTRY_LIST_API_URL
+    }/unranked_items?user=${email}`
     const response = await fetch(url, {
       headers: {
-        authorization: `Basic ${process.env.SLACK_TOKEN}`,
+        authorization: `Basic ${SLACK_TOKEN}`,
         'Content-Type': 'application/json'
       }
     })

--- a/handlers/commands/getRanking.js
+++ b/handlers/commands/getRanking.js
@@ -3,6 +3,7 @@ const fetch = require('node-fetch')
 const { send } = require('micro')
 const { compose } = require('ramda')
 const { handleErrors, requireSlackToken, logRequests } = require('./middleware')
+const { getUserEmail } = require('../../helpers')
 const { PANTRY_LIST_API_URL, SLACK_TOKEN } = process.env
 
 const api = {
@@ -39,9 +40,8 @@ const buildRankingList = (item, index) => ({
 const enhanced = compose(logRequests, handleErrors, requireSlackToken)
 
 module.exports = enhanced(async (req, res) => {
-  const { text, team_domain, token, user_name } = await parse(req)
-  const email = `${user_name}@${team_domain}.com`
-
+  const { text, team_domain, token, user_name, user_id } = await parse(req)
+  const email = await getUserEmail(user_id)
   const response = await getTotalRankings(email)
 
   send(res, 200, response)

--- a/handlers/commands/middleware.js
+++ b/handlers/commands/middleware.js
@@ -32,7 +32,7 @@ const handleErrors = fn => async (req, res) => {
   try {
     return await fn(req, res)
   } catch (err) {
-    sumoLogger.log(err)
+    sumoLogger.log({ err })
     switch (err.name) {
       case 'token':
       case 'required':


### PR DESCRIPTION
We were building user emails from user_name + team_domain, but it's not always the case that user_name equals the first part of your SN email address. So this PR fixes that. 

@SharpNotions/ten-hour-project 